### PR TITLE
work around PDL 2.018+ breakage of PDL::Lite

### DIFF
--- a/lib/Test/PDL.pm
+++ b/lib/Test/PDL.pm
@@ -438,7 +438,7 @@ above example.
 sub test_pdl
 {
 	require Test::Deep::PDL;
-	my $expected = pdl( @_ );
+	my $expected = PDL::Core::pdl( @_ );
 	return Test::Deep::PDL->new( $expected );
 }
 
@@ -490,8 +490,8 @@ This function is not exported. Rather, it must be called as
 sub set_options
 {
 	while( my( $key, $value ) = splice @_, 0, 2 ) {
-		barf( "invalid option $key" ) unless grep { $key eq $_ } keys %OPTIONS;
-		barf( "undefined value for $key" ) unless defined $value;
+		PDL::barf( "invalid option $key" ) unless grep { $key eq $_ } keys %OPTIONS;
+		PDL::barf( "undefined value for $key" ) unless defined $value;
 		$OPTIONS{ $key } = $value;
 	}
 }


### PR DESCRIPTION
@ebaudrez 

Sadly, PDL 2.018+ broke `PDL::Lite` - see https://github.com/PDLPorters/pdl/pull/260. This PR works around that.

You will note this is a PR on the `PDLPorters` repo for `Test::PDL`. I've added you as a collaborator on that, which is only right. I am sort of hoping you will switch to using this as the "main" repo for the module.

Separately, I can't see any good reason why you shouldn't also be in `PDLPorters` - @devel-chm, @zmughal , @drzowie, @d-lamb - any thoughts?